### PR TITLE
Added support for expecting HTTP status codes.

### DIFF
--- a/Sources/SwiftRestRequests/RestApiCaller.swift
+++ b/Sources/SwiftRestRequests/RestApiCaller.swift
@@ -86,7 +86,7 @@ open class RestApiCaller : NSObject {
         request.httpMethod = httpMethod
 
         // Set general headers from REST option object
-        request.setValue(MimeType.ApplicationJson.rawValue, forHTTPHeaderField: HttpHeaders.Accept.rawValue)
+        request.setValue(MimeType.ApplicationJson.rawValue, forHTTPHeaderField: HTTPHeaderKeys.Accept.rawValue)
         if let customHeaders = options.httpHeaders {
             for (httpHeaderKey, httpHeaderValue) in customHeaders {
                 request.setValue(httpHeaderValue, forHTTPHeaderField: httpHeaderKey)
@@ -102,18 +102,22 @@ open class RestApiCaller : NSObject {
 
         // set data with json payload ...
         if let payloadToSend = payload {
-            request.setValue(MimeType.ApplicationJson.rawValue, forHTTPHeaderField: HttpHeaders.ContentType.rawValue)
+            request.setValue(MimeType.ApplicationJson.rawValue, forHTTPHeaderField: HTTPHeaderKeys.ContentType.rawValue)
             request.httpBody = payloadToSend
         }
 
-        // make remote call
         let (data, response) = try await session.data(for: request)
         
         // check http response has a supported type
         guard let httpResponse = response as? HTTPURLResponse else {
             throw RestError.badResponse(response, data)
         }
-
+        
+        // validate service did return one of the expected status codes
+        if let expectedStatusCodes = options.expectedStatusCodes, !expectedStatusCodes.contains(httpResponse.statusCode) {
+            throw RestError.unexpectedHttpStatusCode(httpResponse.statusCode)
+        }
+        
         return (data, httpResponse)
     }
     
@@ -126,7 +130,7 @@ open class RestApiCaller : NSObject {
     ///   - payload: The JSON payload to be sent to server in binary format
     ///   - options: Rest options to use for the data task i.e. timeout
     /// - Returns: The data returned by server and the corresponding `HTTPURLResponse`
-    private func makeCall<T: Deserializer>(_ relativePath: String?, httpMethod: RestMethod, payload: Data?, responseDeserializer: T, options: RestOptions) async throws -> (T.ResponseType?, Int) {
+    private func makeCall<T: Deserializer>(_ relativePath: String?, httpMethod: HTTPMethod, payload: Data?, responseDeserializer: T, options: RestOptions) async throws -> (T.ResponseType?, Int) {
         let (data, httpResponse) = try await dataTask(relativePath: relativePath, httpMethod: httpMethod.rawValue, accept: responseDeserializer.acceptHeader, payload: payload, options: options)
         
         // For requests without deserialization just return status code
@@ -147,7 +151,7 @@ open class RestApiCaller : NSObject {
         
         // Postcondition: data is not empty - contains error or response object!
         
-        let contentType =  httpResponse.value(forHTTPHeaderField: HttpHeaders.ContentType.rawValue)
+        let contentType =  httpResponse.value(forHTTPHeaderField: HTTPHeaderKeys.ContentType.rawValue)
         guard  let contentType, let _ = MimeType(rawValue: contentType) else {
             throw RestError.invalidMimeType(contentType)
         }
@@ -198,7 +202,7 @@ open class RestApiCaller : NSObject {
     /// - returns: A  `Decodable` type of `D` object that was returned from the server or nil together with returned successful httpStatus.
     public func get<D: Decodable>(_ type: D.Type, at relativePath: String? = nil, options: RestOptions = RestOptions()) async throws -> (D?, Int) {
         let decodableDeserializer = DecodableDeserializer<D>()
-        return try await makeCall(relativePath, httpMethod: .Get, payload: nil, responseDeserializer: decodableDeserializer, options: options)
+        return try await makeCall(relativePath, httpMethod: .get, payload: nil, responseDeserializer: decodableDeserializer, options: options)
     }
     
     /// Performs a GET request to the server, capturing the data object type response from the server.
@@ -211,7 +215,7 @@ open class RestApiCaller : NSObject {
     /// - returns: The successful HTTP response status.
     public func get(at relativePath: String? = nil, options: RestOptions = RestOptions()) async throws -> Int {
         let decodableDeserializer = VoidDeserializer()
-        let ( _ , httpStatus) = try await makeCall(relativePath, httpMethod: .Get, payload: nil, responseDeserializer: decodableDeserializer, options: options)
+        let ( _ , httpStatus) = try await makeCall(relativePath, httpMethod: .get, payload: nil, responseDeserializer: decodableDeserializer, options: options)
         return httpStatus
     }
 
@@ -227,7 +231,7 @@ open class RestApiCaller : NSObject {
     public func post<E: Encodable, D: Decodable>(_ encodable: E, at relativePath: String? = nil, responseType type: D.Type, options: RestOptions = RestOptions()) async throws -> (D?, Int) {
         let payload = try JSONEncoder().encode(encodable)
         let decodableDeserializer = DecodableDeserializer<D>()
-        return try await makeCall(relativePath, httpMethod: .Post, payload: payload, responseDeserializer: decodableDeserializer, options: options)
+        return try await makeCall(relativePath, httpMethod: .post, payload: payload, responseDeserializer: decodableDeserializer, options: options)
     }
     
     
@@ -243,7 +247,7 @@ open class RestApiCaller : NSObject {
     public func post<E: Encodable>(_ encodable: E, at relativePath: String? = nil, options: RestOptions = RestOptions()) async throws -> Int {
         let payload = try JSONEncoder().encode(encodable)
         let decodableDeserializer = VoidDeserializer()
-        let ( _ , httpStatus) = try await makeCall(relativePath, httpMethod: .Post, payload: payload, responseDeserializer: decodableDeserializer, options: options)
+        let ( _ , httpStatus) = try await makeCall(relativePath, httpMethod: .post, payload: payload, responseDeserializer: decodableDeserializer, options: options)
         return httpStatus
     }
     
@@ -261,7 +265,7 @@ open class RestApiCaller : NSObject {
     public func put<E: Encodable, D: Decodable>(_ encodable: E, at relativePath: String? = nil, responseType type: D.Type, options: RestOptions = RestOptions()) async throws -> (D?, Int) {
         let payload = try JSONEncoder().encode(encodable)
         let decodableDeserializer = DecodableDeserializer<D>()
-        return try await makeCall(relativePath, httpMethod: .Put, payload: payload, responseDeserializer: decodableDeserializer, options: options)
+        return try await makeCall(relativePath, httpMethod: .put, payload: payload, responseDeserializer: decodableDeserializer, options: options)
     }
     
     /// Performs a PUT request to the server, capturing the HTTP response status.
@@ -276,7 +280,7 @@ open class RestApiCaller : NSObject {
     public func put<E: Encodable>(_ encodable: E, at relativePath: String? = nil, options: RestOptions = RestOptions()) async throws ->  Int {
         let payload = try JSONEncoder().encode(encodable)
         let voidDeserializer = VoidDeserializer()
-        let (_, httpStatus) = try await makeCall(relativePath, httpMethod: .Put, payload: payload, responseDeserializer: voidDeserializer, options: options)
+        let (_, httpStatus) = try await makeCall(relativePath, httpMethod: .put, payload: payload, responseDeserializer: voidDeserializer, options: options)
         return httpStatus
     }
     
@@ -293,7 +297,7 @@ open class RestApiCaller : NSObject {
     public func delete<E: Encodable, D: Decodable>(_ encodable: E, at relativePath: String? = nil, responseType type: D.Type, options: RestOptions = RestOptions()) async throws -> (D?, Int) {
         let payload = try JSONEncoder().encode(encodable)
         let decodableDeserializer = DecodableDeserializer<D>()
-        return try await makeCall(relativePath, httpMethod: .Delete, payload: payload, responseDeserializer: decodableDeserializer, options: options)
+        return try await makeCall(relativePath, httpMethod: .delete, payload: payload, responseDeserializer: decodableDeserializer, options: options)
     }
     
     /// Performs a PATCH request to the server, capturing the `JSON` response from the server.
@@ -308,7 +312,7 @@ open class RestApiCaller : NSObject {
     public func patch<E: Encodable, D: Decodable>(_ encodable: E, at relativePath: String? = nil, responseType type: D.Type, options: RestOptions = RestOptions()) async throws -> (D?, Int)  {
         let payload = try JSONEncoder().encode(encodable)
         let decodableDeserializer = DecodableDeserializer<D>()
-        return try await makeCall(relativePath, httpMethod: .Patch, payload: payload, responseDeserializer: decodableDeserializer, options: options)
+        return try await makeCall(relativePath, httpMethod: .patch, payload: payload, responseDeserializer: decodableDeserializer, options: options)
     }
     
 }

--- a/Sources/SwiftRestRequests/RestError.swift
+++ b/Sources/SwiftRestRequests/RestError.swift
@@ -30,7 +30,6 @@ public enum RestError: Error {
     /// - parameter Data: The raw returned data from the server.
     case badResponse(URLResponse, Data)
     
-    
     /// Indicates that the server responded with an unexpected mime type
     /// - parameter String: The returned mimetype
     case invalidMimeType(String?)
@@ -41,10 +40,15 @@ public enum RestError: Error {
     /// - parameter Error: The original system error (like a DecodingError, etc) that caused the malformedResponse to trigger
     case malformedResponse(HTTPURLResponse, Data, Error)
     
-    
-    // Indicates the api call to server was not successful and optional contains an error json object.
+    /// Indicates the api call to server was not successful and optional contains an error json object.
     /// - parameter HTTPURLResponse: The HTTPURLResponse from the server
     /// - parameter Int: The returned HTTP error status
     /// - parameter Error: The returned json error object
     case failedRestCall(HTTPURLResponse, Int, Any?)
+    
+    /// Indicates the service the service did return un unexpected HTTP status code.
+    /// Note: You can set the expected HTTP status codes in the RestOptions. If this list is nil all status codes are allowed.
+    ///  - parameter HTTP status code that was returned from the server.
+    case unexpectedHttpStatusCode(Int)
+    
 }

--- a/Sources/SwiftRestRequests/RestOptions.swift
+++ b/Sources/SwiftRestRequests/RestOptions.swift
@@ -34,5 +34,9 @@ public struct RestOptions {
     /// An optional set of query parameters to send with the call.
     public var queryParameters: [String: String]?
     
+    /// The http status codes the service is expecting to throw. Default is nil - all status codes allwed. 
+    /// Note: If services returns another HTTP status code this will triggger an error during the call.
+    public var expectedStatusCodes: [Int]? = nil
+    
     public init() {}
 }

--- a/Sources/SwiftRestRequests/RestUtil.swift
+++ b/Sources/SwiftRestRequests/RestUtil.swift
@@ -22,13 +22,14 @@
 import Foundation
 
 
-/// Supported HTTP methods to exectue  REST requests
-internal enum RestMethod: String {
-    case Post = "POST"
-    case Patch = "PATCH"
-    case Get = "GET"
-    case Put = "PUT"
-    case Delete = "DELETE"
+/// Type representing HTTP methods. Raw `String` value is stored and compared case-sensitively.
+///
+internal enum HTTPMethod: String {
+    case post = "POST"
+    case patch = "PATCH"
+    case get = "GET"
+    case put = "PUT"
+    case delete = "DELETE"
     
 }
 
@@ -40,7 +41,7 @@ internal enum MimeType: String {
     case Void = "*/*"
 }
 
-internal enum HttpHeaders: String {
+internal enum HTTPHeaderKeys: String {
     case ContentType = "Content-Type"
     case Accept = "Accept"
 }

--- a/Tests/SwiftRestRequestsTests/RestApiCallerTests.swift
+++ b/Tests/SwiftRestRequestsTests/RestApiCallerTests.swift
@@ -108,7 +108,7 @@ extension RestApiCallerTests {
 
 extension RestApiCallerTests {
     
-    private func makePostOrPutCallWithEncodable(_ method: RestMethod) async throws {
+    private func makePostOrPutCallWithEncodable(_ method: HTTPMethod) async throws {
         
         struct HttpBinRequest: Codable, Equatable {
             let key1: String
@@ -129,7 +129,7 @@ extension RestApiCallerTests {
        
         var result: (response: HttpBinResponse?, httpStatus: Int)
         
-        if method == .Post {
+        if method == .post {
             result = try await apiCaller.post(request, at: "post", responseType: HttpBinResponse.self)
         } else  {
             // Postcondition: method == PUT
@@ -140,7 +140,7 @@ extension RestApiCallerTests {
         XCTAssertEqual(result.response?.json, request)
     }
     
-    private func makePostOrPutCallWithoutDecodable(_ method: RestMethod) async throws {
+    private func makePostOrPutCallWithoutDecodable(_ method: HTTPMethod) async throws {
         struct HttpBinRequest: Codable {
             let key1: String
             let key2: Int
@@ -153,7 +153,7 @@ extension RestApiCallerTests {
         
         var successStatus: Int
         
-        if method == .Post {
+        if method == .post {
            successStatus = try await apiCaller.post(request, at: "status/204")
         } else {
             // Postcondition: method == PUT
@@ -164,19 +164,53 @@ extension RestApiCallerTests {
     }
     
     func testPostWithDecodable() async throws {
-        try await makePostOrPutCallWithEncodable(.Post)
+        try await makePostOrPutCallWithEncodable(.post)
     }
 
     func testPutWithDecodable() async throws {
-        try await makePostOrPutCallWithEncodable(.Put)
+        try await makePostOrPutCallWithEncodable(.put)
     }
     
     func testPostWithoutDecodable() async throws {
-        try await makePostOrPutCallWithoutDecodable(.Post)
+        try await makePostOrPutCallWithoutDecodable(.post)
     }
     
     func testPutWithoutDecodable() async throws {
-        try await makePostOrPutCallWithoutDecodable(.Put)
+        try await makePostOrPutCallWithoutDecodable(.put)
+    }
+    
+}
+
+// MARK: - Check services are only returning expected status codes
+
+extension RestApiCallerTests {
+    
+    func testExpectedStatusCodeReturned() async throws {
+        var options = RestOptions()
+        
+        // define common status codes expected
+        let expectedStatusCodes = [500, 200, 204, 403]
+        options.expectedStatusCodes = expectedStatusCodes
+
+        for statusCode in expectedStatusCodes {
+            let returnedStatus =  try await apiCaller.get(at: "status/\(statusCode)", options: options)
+            XCTAssertEqual(statusCode, returnedStatus)
+        }
+    }
+    
+    func testExpectedStatusCodeNotReturned() async throws {
+        var options = RestOptions()
+        
+        // define common status codes expected
+        let expectedStatusCodes = [500, 200, 204, 403]
+        options.expectedStatusCodes = expectedStatusCodes
+        
+        do {
+            let _ = try await apiCaller.get(at: "status/501", options: options)
+            XCTFail("Above call should throw errror")
+        } catch RestError.unexpectedHttpStatusCode(let statusCode) {
+            XCTAssertEqual(501, statusCode)
+        }
     }
     
 }


### PR DESCRIPTION
It is possible to define a set of HTTP status codes that are expected to be returned from a REST endpoint using RestOptions. The runtime will check if the effective HTTP status code matches one of the expected ones. 