### PR TITLE
Refactor REST makeCall logic

### DIFF
--- a/Sources/SwiftRestRequests/RestApiCaller.swift
+++ b/Sources/SwiftRestRequests/RestApiCaller.swift
@@ -278,65 +278,59 @@ open class RestApiCaller : NSObject {
        
         let httpStatus = httpResponse.status
         
-        // For requests without deserialization and no error just return the status
-        if type(of: responseDeserializer) == VoidDeserializer.self || httpStatus == .noContent {
-            if httpStatus.type == .success {
-                return (nil, httpResponse.status)
-            }
+        if shouldBypassDeserialization(responseDeserializer, status: httpStatus),
+           httpStatus.type == .success {
+            return (nil, httpStatus)
         }
         
         guard !data.isEmpty  else {
             throw RestError.failedRestCall(httpResponse, httpStatus, error: nil)
         }
         
-        // Postcondition: We have a response object or  error that needs to be parsed!
-        
-        let contentType =  httpResponse.value(forHTTPHeaderField: HTTPHeaderKeys.ContentType.rawValue)
-        
-        // Note: some servers return also encoding i.e. Content-Type: application/json; charset=utf-8 take the first part
-        let firstContentMimeType = contentType?.components(separatedBy: ";").first
-        
-        guard  let firstContentMimeType, let _ = MimeType(rawValue: firstContentMimeType) else {
-            throw RestError.invalidMimeType(contentType)
-        }
-        
-        // Postcondition: Response or error ContentTyp is supported
+        _ = try validatedMimeType(from: httpResponse)
         
         if httpStatus.type == .success  {
-            
-            // Postcondition: httpStatus in 200...299
-            if httpStatus == .ok {
-                // Postcondition: httpStatus is 200 we need to deserialize
-                do {
-                    let transformedResponse = try responseDeserializer.deserialize(data)
-                    return (transformedResponse, httpResponse.status)
-                } catch {
-                    throw RestError.malformedResponse(httpResponse, data, error)
-                }
-            } else {
-                // Postcondition: httpStatus is 201...299
-                // Note: we skipt data in this case
-                return (nil, httpStatus)
-            }
-            
-        } else {
-            
-            // Postcondition: httpStatus not 2XX. We have an error and error data
-            var failedRestCallError: RestError
-            
-            do {
-                let errorJson = try errorDeserializer?.deserialize(data)
-                failedRestCallError =  RestError.failedRestCall(httpResponse, httpStatus, error: errorJson)
-            } catch {
-                throw RestError.malformedResponse(httpResponse, data, error)
-            }
-            
-            throw failedRestCallError
-            
+            let transformedResponse = try decodeSuccessfulResponse(data: data, response: httpResponse, deserializer: responseDeserializer)
+            return (transformedResponse, httpStatus)
         }
-            
+
+        throw try buildErrorResponse(data: data, response: httpResponse, status: httpStatus)
     }
 
+    private func shouldBypassDeserialization<T: Deserializer>(_ deserializer: T, status: HTTPStatusCode) -> Bool {
+        (deserializer is VoidDeserializer) || status == .noContent
+    }
+
+    private func validatedMimeType(from response: HTTPURLResponse) throws -> MimeType {
+        let contentType = response.value(forHTTPHeaderField: HTTPHeaderKeys.ContentType.rawValue)
+        let firstContentMimeType = contentType?.components(separatedBy: ";").first
+        
+        guard let firstContentMimeType,
+              let mimeType = MimeType(rawValue: firstContentMimeType) else {
+            throw RestError.invalidMimeType(contentType)
+        }
+        return mimeType
+    }
+    
+    private func decodeSuccessfulResponse<T: Deserializer>(data: Data, response: HTTPURLResponse, deserializer: T) throws -> T.ResponseType? {
+        if response.status == .ok {
+            do {
+                return try deserializer.deserialize(data)
+            } catch {
+                throw RestError.malformedResponse(response, data, error)
+            }
+        }
+        return nil
+    }
+
+    private func buildErrorResponse(data: Data, response: HTTPURLResponse, status: HTTPStatusCode) throws -> RestError {
+        do {
+            let errorPayload = try errorDeserializer?.deserialize(data)
+            return RestError.failedRestCall(response, status, error: errorPayload)
+        } catch {
+            throw RestError.malformedResponse(response, data, error)
+        }
+    }
     
     
 // MARK: Public API that can be used from other classes or subclass

--- a/Sources/SwiftRestRequests/RestApiCaller.swift
+++ b/Sources/SwiftRestRequests/RestApiCaller.swift
@@ -278,6 +278,7 @@ open class RestApiCaller : NSObject {
        
         let httpStatus = httpResponse.status
         
+        // For requests without deserialization and no error just return the status
         if shouldBypassDeserialization(responseDeserializer, status: httpStatus),
            httpStatus.type == .success {
             return (nil, httpStatus)
@@ -286,6 +287,8 @@ open class RestApiCaller : NSObject {
         guard !data.isEmpty  else {
             throw RestError.failedRestCall(httpResponse, httpStatus, error: nil)
         }
+        
+        // Postcondition: We have a response object or  error that needs to be parsed!
         
         _ = try validatedMimeType(from: httpResponse)
         


### PR DESCRIPTION
### **User description**
Refactored makeCall into smaller helpers so MIME validation, success decoding, and error construction each live in focused private methods. The main flow now early-exits for bodyless responses, validates the content type, decodes success payloads, or builds structured errors.


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored `makeCall` into focused private helper methods

- Extracted `shouldBypassDeserialization` for early-exit logic

- Extracted `validatedMimeType` for MIME type validation

- Extracted `decodeSuccessfulResponse` for success payload deserialization

- Extracted `buildErrorResponse` for structured error construction

- Improved code readability and testability with clearer separation of concerns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  makeCall["makeCall<br/>Main orchestrator"] --> bypass["shouldBypassDeserialization<br/>Early-exit check"]
  makeCall --> validate["validatedMimeType<br/>MIME validation"]
  makeCall --> decode["decodeSuccessfulResponse<br/>Success deserialization"]
  makeCall --> error["buildErrorResponse<br/>Error construction"]
  bypass --> result1["Return nil response"]
  decode --> result2["Return deserialized data"]
  error --> result3["Throw RestError"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RestApiCaller.swift</strong><dd><code>Extract makeCall logic into focused helper methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/RestApiCaller.swift

<ul><li>Refactored <code>makeCall</code> method by extracting four private helper methods<br> <li> <code>shouldBypassDeserialization</code> checks if deserialization should be <br>skipped<br> <li> <code>validatedMimeType</code> validates and returns the MIME type from response <br>headers<br> <li> <code>decodeSuccessfulResponse</code> handles successful response deserialization <br>with error handling<br> <li> <code>buildErrorResponse</code> constructs structured error responses from error <br>data<br> <li> Simplified main flow with early exits and clearer success/error <br>branching</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/14/files#diff-eca05e20a1c02fc0d2ffa8734b5d7287738d9920f8a164f95438472568515152">+36/-39</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

