### PR TITLE
- Added a shared TrustValidation.extractServerTrust helper to central…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -24,12 +24,16 @@ let package = Package(
             name: "SwiftRestRequests",
             dependencies: [.product(name: "Logging", package: "swift-log")],
             swiftSettings: [
-                .enableUpcomingFeature("StrictConcurrency")
-                // .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny")
             ]
         ),
         .testTarget(
             name: "SwiftRestRequestsTests",
-            dependencies: ["SwiftRestRequests"]),
+            dependencies: ["SwiftRestRequests"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
     ]
 )

--- a/Sources/SwiftRestRequests/Deserializer.swift
+++ b/Sources/SwiftRestRequests/Deserializer.swift
@@ -22,7 +22,7 @@
 import Foundation
 
 /// Deserializes raw network data into strongly typed Swift values.
-public protocol Deserializer {
+public protocol Deserializer: Sendable {
 
     associatedtype ResponseType: Sendable
 
@@ -40,7 +40,7 @@ public protocol Deserializer {
 
 
 /// A generic deserializer that uses `JSONDecoder` to decode a `Decodable` value.
-public final class DecodableDeserializer<T: Decodable & Sendable>: Deserializer {
+public struct DecodableDeserializer<T: Decodable & Sendable>: Deserializer {
 
     public typealias ResponseType = T
 
@@ -55,7 +55,7 @@ public final class DecodableDeserializer<T: Decodable & Sendable>: Deserializer 
 
 
 /// A deserializer representing empty responses (`Void`).
-public final class VoidDeserializer: Deserializer {
+public struct VoidDeserializer: Deserializer {
 
     public typealias ResponseType = Void
 
@@ -65,19 +65,19 @@ public final class VoidDeserializer: Deserializer {
     
     public func deserialize(_ data: Data) throws -> Void {
         assert(data.isEmpty) // no data should be returned
-        return Void()
+        return ()
     }
 }
 
 
 /// A deserializer that emits the raw payload `Data`.
-public final class DataDeserializer: Deserializer {
+public struct DataDeserializer: Deserializer {
 
     public typealias ResponseType = Data
 
     public let acceptHeader = MimeType.ApplicationOctetStream.rawValue
 
-    public required init() { }
+    public init() { }
 
     public func deserialize(_ data: Data) throws -> Data {
         return data

--- a/Sources/SwiftRestRequests/RestError.swift
+++ b/Sources/SwiftRestRequests/RestError.swift
@@ -49,7 +49,7 @@ public enum RestError: Error {
     ///   - HTTPURLResponse: The HTTPURLResponse from the server.
     ///   - Data: The raw returned data from the server.
     ///   - Error: The original system error (like a `DecodingError`) that triggered the failure.
-    case malformedResponse(HTTPURLResponse, Data, Error)
+    case malformedResponse(HTTPURLResponse, Data, any Error)
     
     /// Indicates the API call failed and optionally surfaces the parsed error payload.
     /// - Parameters:

--- a/Sources/SwiftRestRequests/interceptors/LogNetworkInterceptor.swift
+++ b/Sources/SwiftRestRequests/interceptors/LogNetworkInterceptor.swift
@@ -19,7 +19,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-import Foundation
+@preconcurrency import Foundation
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -118,5 +118,4 @@ extension Data {
         return prettyPrintedString
     }
 }
-
 

--- a/Sources/SwiftRestRequests/linux/URLSession+Linux.swift
+++ b/Sources/SwiftRestRequests/linux/URLSession+Linux.swift
@@ -20,7 +20,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 
-import Foundation
+@preconcurrency import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 

--- a/Sources/SwiftRestRequests/logging/Logger+Extension.swift
+++ b/Sources/SwiftRestRequests/logging/Logger+Extension.swift
@@ -29,11 +29,10 @@ extension Logger {
     /// Logger namespace providing shared instances for the package.
     public actor SwiftRestRequests {
         /// Logger used by request/response interceptors.
-        public static var interceptor = Logger(label: labelPrefix + "Interceptor")
+        public nonisolated(unsafe) static var interceptor = Logger(label: labelPrefix + "Interceptor")
         /// Logger used by security-related components.
-        public static var security = Logger(label: labelPrefix + "Security")
+        public nonisolated(unsafe) static var security = Logger(label: labelPrefix + "Security")
         /// Logger used by the main `RestApiCaller`.
-        public static var apiCaller = Logger(label: labelPrefix + "ApiCaller")
+        public nonisolated(unsafe) static var apiCaller = Logger(label: labelPrefix + "ApiCaller")
     }
 }
-

--- a/Sources/SwiftRestRequests/security/AuthorizerInterceptor.swift
+++ b/Sources/SwiftRestRequests/security/AuthorizerInterceptor.swift
@@ -19,7 +19,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-import Foundation
+@preconcurrency import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
@@ -29,9 +29,9 @@ import FoundationNetworking
 public class AuthorizerInterceptor: URLRequestInterceptor {
     
     /// Authorizer applied to each request.
-    public let authorizer: URLRequestAuthorizer
+    public let authorizer: any URLRequestAuthorizer
     
-    init(authorization: URLRequestAuthorizer) {
+    init(authorization: any URLRequestAuthorizer) {
         self.authorizer = authorization
     }
     

--- a/Sources/SwiftRestRequests/security/TrustValidation.swift
+++ b/Sources/SwiftRestRequests/security/TrustValidation.swift
@@ -1,0 +1,37 @@
+//
+// TrustValidation.swift
+//
+// This File belongs to SwiftRestRequests
+// Copyright © 2024 Thomas Kausch.
+// All Rights Reserved.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+import Logging
+
+enum TrustValidation {
+    static func extractServerTrust(from challenge: URLAuthenticationChallenge, logger: Logger) -> SecTrust? {
+        guard let serverTrust = challenge.protectionSpace.serverTrust else {
+            logger.error("Security: serverTrust is missing; cancelling authentication challenge.")
+            return nil
+        }
+        return serverTrust
+    }
+}

--- a/Sources/SwiftRestRequests/security/TrustValidation.swift
+++ b/Sources/SwiftRestRequests/security/TrustValidation.swift
@@ -19,7 +19,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-import Foundation
+@preconcurrency import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif

--- a/Sources/SwiftRestRequests/security/URLRequestAuthorizer.swift
+++ b/Sources/SwiftRestRequests/security/URLRequestAuthorizer.swift
@@ -38,7 +38,7 @@ public protocol URLRequestAuthorizer {
 /// Configures `Authorization` headers for HTTP Basic authentication.
 public class BasicRequestAuthorizer: URLRequestAuthorizer {
     
-    let logger = Logger.SwiftRestRequests.security
+    let logger: Logger
     
     public let username: String
     public let password: String
@@ -49,9 +49,11 @@ public class BasicRequestAuthorizer: URLRequestAuthorizer {
     /// - Parameters:
     ///   - username: The username to be used for authorization
     ///   - password: The password to be used for authorization
-    public init(username: String, password: String) {
+    ///   - logger: Destination for security trace logging.
+    public init(username: String, password: String, logger: Logger = Logger.SwiftRestRequests.security) {
         self.username = username
         self.password = password
+        self.logger = logger
 
         /// Pre-calculate the header value so we don't do the conversion and encoding on each call
         let credentials = "\(self.username):\(self.password)"
@@ -69,17 +71,20 @@ public class BasicRequestAuthorizer: URLRequestAuthorizer {
 }
 
 /// Configures `Authorization` headers for Bearer token authentication.
-public class BearerReqeustAuthorizer: URLRequestAuthorizer {
+public class BearerRequestAuthorizer: URLRequestAuthorizer {
     
-    let logger = Logger.SwiftRestRequests.security
+    let logger: Logger
     
     // The token value (without `Bearer` prefix) to be used for the HTTP `Authorization` request header.
     public var token: String
     
     /// Creates a Bearer authorization helper with the provided token.
-    /// - Parameter token: Token value (without `Bearer` prefix) inserted into the header.
-    public init(token: String) {
+    /// - Parameters:
+    ///   - token: Token value (without `Bearer` prefix) inserted into the header.
+    ///   - logger: Destination for security trace logging.
+    public init(token: String, logger: Logger = Logger.SwiftRestRequests.security) {
         self.token = token
+        self.logger = logger
     }
     
     /// Applies the Bearer authorization header to the request.

--- a/Sources/SwiftRestRequests/security/URLRequestAuthorizer.swift
+++ b/Sources/SwiftRestRequests/security/URLRequestAuthorizer.swift
@@ -20,7 +20,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 
-import Foundation
+@preconcurrency import Foundation
 import Logging
 
 #if canImport(FoundationNetworking)
@@ -30,7 +30,7 @@ import FoundationNetworking
 
 
 /// Protocol adopted by components that can apply authentication headers to requests.
-public protocol URLRequestAuthorizer {
+@preconcurrency public protocol URLRequestAuthorizer {
     /// Updates the request with the appropriate authorization header.
     func configureAuthorizationHeader(for urlRequest: inout URLRequest);
 }

--- a/Tests/SwiftRestRequestsTests/AbstractRestApiCallerTests.swift
+++ b/Tests/SwiftRestRequestsTests/AbstractRestApiCallerTests.swift
@@ -4,6 +4,7 @@
 // All Rights Reserved.
 
 import XCTest
+import Foundation
 @testable import SwiftRestRequests
 
 
@@ -12,11 +13,17 @@ import Logging
 
 class AbstractRestApiCallerTests: XCTestCase {
 
-    // When available we prefere to use the OSLog
-    static var onceExecution: () = {
+    private static let loggingLock = NSLock()
+
+    override class func setUp() {
+        super.setUp()
+
+        // Synchronize access to global logger state
+        loggingLock.lock()
+        defer { loggingLock.unlock() }
         
         #if os(Linux)
-           // Configure `swift-log`default logger
+            // Configure `swift-log` default logger
         #else
             /// Configure `swift-log` logging system to use OSLog backend
             LoggingSystem.bootstrap(OSLogHandler.init)
@@ -25,14 +32,6 @@ class AbstractRestApiCallerTests: XCTestCase {
         Logger.SwiftRestRequests.security.logLevel = .trace
         Logger.SwiftRestRequests.interceptor.logLevel = .trace
         Logger.SwiftRestRequests.apiCaller.logLevel = .trace
-        
-    }()
-    
-    
-    override func setUp()  {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-        let _ = AbstractRestApiCallerTests.onceExecution
-        
-    }
 
+    }
 }

--- a/Tests/SwiftRestRequestsTests/RestApiCallerSecurityTests.swift
+++ b/Tests/SwiftRestRequestsTests/RestApiCallerSecurityTests.swift
@@ -52,7 +52,7 @@ final class RestApiCallerSecurityTests: AbstractRestApiCallerTests {
             let token: String
         }
         
-        let authorizer = BearerReqeustAuthorizer(token: BearerToken)
+        let authorizer = BearerRequestAuthorizer(token: BearerToken)
         let caller = RestApiCaller(baseUrl: url, authorizer: authorizer, enableNetworkTrace: true)
         
         var (response, httpStatus) = try await caller.get(HttpBinBearerResponse.self, at: "bearer")


### PR DESCRIPTION
### **User description**
- CertificateCAPinning and PublicKeyServerPinning now reuse it and emit consistent success/failure messages.
- Renamed BearerReqeustAuthorizer to BearerRequestAuthorizer, added optional logger injection to both Basic and Bearer authorizers, and updated their logging internals


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Centralized SecTrust extraction logic into new `TrustValidation.extractServerTrust` helper

- Unified error messages and logging across pinning delegates for consistency

- Refactored pinning validation logic using guard statements for clarity

- Added optional logger injection to Basic and Bearer authorizers

- Fixed typo: renamed `BearerReqeustAuthorizer` to `BearerRequestAuthorizer`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TrustValidation<br/>extractServerTrust"] --> B["CertificateCAPinning"]
  A --> C["PublicKeyServerPinning"]
  D["BasicRequestAuthorizer<br/>optional logger"] --> E["URLRequestAuthorizer"]
  F["BearerRequestAuthorizer<br/>fixed typo + logger"] --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TrustValidation.swift</strong><dd><code>New shared trust validation helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/security/TrustValidation.swift

<ul><li>New file created to centralize SecTrust extraction logic<br> <li> Provides <code>extractServerTrust</code> static method that validates and logs <br>missing trust<br> <li> Eliminates code duplication across pinning delegates</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/15/files#diff-d4d0a45c04b5e157dfa7f2611a6619f919c3d11275d995bb03180f0c1d392444">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CertificateCAPinning.swift</strong><dd><code>Refactor to use centralized trust validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/security/CertificateCAPinning.swift

<ul><li>Replaced inline serverTrust extraction with <br><code>TrustValidation.extractServerTrust</code> call<br> <li> Refactored validation logic using guard statement instead of if-else<br> <li> Standardized error and success log messages for consistency<br> <li> Improved code readability and reduced duplication</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/15/files#diff-a561e75590448d0dd9cef699d5fb9f7355ee8b28c36dda3dae2817ccd0cc4229">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PublicKeyServerPinning.swift</strong><dd><code>Refactor to use centralized trust validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/security/PublicKeyServerPinning.swift

<ul><li>Replaced inline serverTrust extraction with <br><code>TrustValidation.extractServerTrust</code> call<br> <li> Simplified public key validation logic using nested guard statements<br> <li> Standardized error and success log messages for consistency<br> <li> Removed redundant error handling branches</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/15/files#diff-9dfe8ea8c3fb81c54b35e1e2ae6365d218cb1ce9bf2b7404b47e9a556d5bdc5c">+12/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>URLRequestAuthorizer.swift</strong><dd><code>Add optional logger injection and fix typo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/security/URLRequestAuthorizer.swift

<ul><li>Added optional <code>logger</code> parameter to <code>BasicRequestAuthorizer</code> constructor <br>with default value<br> <li> Added optional <code>logger</code> parameter to <code>BearerRequestAuthorizer</code> constructor <br>with default value<br> <li> Fixed typo: renamed <code>BearerReqeustAuthorizer</code> to <code>BearerRequestAuthorizer</code><br> <li> Changed logger from hardcoded instance to injectable dependency<br> <li> Updated documentation to reflect new logger parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/15/files#diff-14c2b325f6b5e8b13057b02d3ab54cff529416549767cafff908d2964ad7f447">+11/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RestApiCallerSecurityTests.swift</strong><dd><code>Update test for renamed authorizer class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Tests/SwiftRestRequestsTests/RestApiCallerSecurityTests.swift

<ul><li>Updated test to use corrected class name <code>BearerRequestAuthorizer</code><br> <li> Maintains existing test functionality with fixed authorizer <br>instantiation</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/15/files#diff-9a91ffc49468b67e249a0b380c6f9d2a42e92836b361dc1ea549bc935735ad47">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

