### PR TITLE
RestApi Refactoring with named Parameters and better Localization.

### DIFF
--- a/Sources/SwiftRestRequests/RestApiCaller.swift
+++ b/Sources/SwiftRestRequests/RestApiCaller.swift
@@ -203,7 +203,7 @@ open class RestApiCaller : NSObject {
     @inline(__always)
     private func validateResponseStatusCodes(_ expectedStatusCodes: [HTTPStatusCode]?, _ httpResponse: HTTPURLResponse) throws {
         if let expectedStatusCodes, !expectedStatusCodes.contains(httpResponse.status) {
-            throw RestError.unexpectedHttpStatusCode(httpResponse.statusCode)
+            throw RestError.unexpectedHttpStatusCode(statusCode: httpResponse.statusCode)
         }
     }
     
@@ -251,7 +251,7 @@ open class RestApiCaller : NSObject {
         
         // check http response has a supported type
         guard let httpResponse = response as? HTTPURLResponse else {
-            throw RestError.badResponse(response, data)
+            throw RestError.badResponse(response: response, data: data)
         }
         
         callReceiveInterceptors(data, httpResponse)
@@ -283,7 +283,7 @@ open class RestApiCaller : NSObject {
         }
         
         guard !data.isEmpty  else {
-            throw RestError.failedRestCall(httpResponse, httpStatus, error: nil)
+            throw RestError.failedRestCall(response: httpResponse, status: httpStatus, errorPayload: nil)
         }
         
         // Postcondition: We have a response object or  error that needs to be parsed!
@@ -308,7 +308,7 @@ open class RestApiCaller : NSObject {
         
         guard let firstContentMimeType,
               let mimeType = MimeType(rawValue: firstContentMimeType) else {
-            throw RestError.invalidMimeType(contentType)
+            throw RestError.invalidMimeType(mimeType: contentType)
         }
         return mimeType
     }
@@ -318,7 +318,7 @@ open class RestApiCaller : NSObject {
             do {
                 return try deserializer.deserialize(data)
             } catch {
-                throw RestError.malformedResponse(response, data, error)
+                throw RestError.malformedResponse(response: response, data: data, underlying: error)
             }
         }
         return nil
@@ -327,9 +327,9 @@ open class RestApiCaller : NSObject {
     private func buildErrorResponse(data: Data, response: HTTPURLResponse, status: HTTPStatusCode) throws -> RestError {
         do {
             let errorPayload = try errorDeserializer?.deserialize(data)
-            return RestError.failedRestCall(response, status, error: errorPayload)
+            return RestError.failedRestCall(response: response, status: status, errorPayload: errorPayload)
         } catch {
-            throw RestError.malformedResponse(response, data, error)
+            throw RestError.malformedResponse(response: response, data: data, underlying: error)
         }
     }
     

--- a/Sources/SwiftRestRequests/http/HTTPUtil.swift
+++ b/Sources/SwiftRestRequests/http/HTTPUtil.swift
@@ -33,7 +33,7 @@ internal enum HTTPMethod: String {
 }
 
 /// MIME types referenced throughout the client.
-internal enum MimeType: String {
+internal enum MimeType: String, CaseIterable {
     case ApplicationJson =  "application/json"
     case TextPlain = "text/plain"
     case ApplicationOctetStream = "application/octet-stream"

--- a/Tests/SwiftRestRequestsTests/AbstractRestApiCallerTests.swift
+++ b/Tests/SwiftRestRequestsTests/AbstractRestApiCallerTests.swift
@@ -18,6 +18,11 @@ class AbstractRestApiCallerTests: XCTestCase {
     override class func setUp() {
         super.setUp()
 
+        // ***********************************************************
+        // IMPORTANT NOTE: You must run httpbin locally for testing!!!
+        // docker run -p 80:80 kennethreitz/httpbin
+        // ************************************************************
+        
         // Synchronize access to global logger state
         loggingLock.lock()
         defer { loggingLock.unlock() }
@@ -26,7 +31,7 @@ class AbstractRestApiCallerTests: XCTestCase {
             // Configure `swift-log` default logger
         #else
             /// Configure `swift-log` logging system to use OSLog backend
-            LoggingSystem.bootstrap(OSLogHandler.init)
+            // LoggingSystem.bootstrap(OSLogHandler.init)
         #endif
         
         Logger.SwiftRestRequests.security.logLevel = .trace


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactor `RestError` enum cases to use named parameters for clarity

- Add `LocalizedError` conformance with localized descriptions and recovery suggestions

- Implement `CustomDebugStringConvertible` for improved debugging output

- Add `Equatable` conformance to enable error comparison in tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RestError enum"] -->|"Add named parameters"| B["Improved API clarity"]
  A -->|"Implement LocalizedError"| C["User-friendly messages"]
  A -->|"Add CustomDebugStringConvertible"| D["Better debugging"]
  A -->|"Implement Equatable"| E["Test support"]
  B --> F["Enhanced RestError"]
  C --> F
  D --> F
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RestApiCaller.swift</strong><dd><code>Update RestError instantiations with named parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/RestApiCaller.swift

<ul><li>Update all <code>RestError</code> case instantiations to use named parameters<br> <li> Change <code>unexpectedHttpStatusCode(httpResponse.statusCode)</code> to <br><code>unexpectedHttpStatusCode(statusCode: httpResponse.statusCode)</code><br> <li> Change <code>badResponse(response, data)</code> to <code>badResponse(response: response, </code><br><code>data: data)</code><br> <li> Change <code>failedRestCall(httpResponse, httpStatus, error: nil)</code> to <br><code>failedRestCall(response: httpResponse, status: httpStatus, </code><br><code>errorPayload: nil)</code><br> <li> Change <code>invalidMimeType(contentType)</code> to <code>invalidMimeType(mimeType: </code><br><code>contentType)</code><br> <li> Change <code>malformedResponse(response, data, error)</code> to <br><code>malformedResponse(response: response, data: data, underlying: error)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/18/files#diff-eca05e20a1c02fc0d2ffa8734b5d7287738d9920f8a164f95438472568515152">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestError.swift</strong><dd><code>Add localization and debugging support to RestError</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/RestError.swift

<ul><li>Refactor all <code>RestError</code> cases to use named parameters instead of <br>positional arguments<br> <li> Update documentation comments to describe parameters with improved <br>clarity and detail<br> <li> Add <code>LocalizedError</code> extension with <code>errorDescription</code> and <br><code>recoverySuggestion</code> properties for user-friendly error messages<br> <li> Add <code>CustomDebugStringConvertible</code> extension providing detailed debug <br>output for each error case<br> <li> Add <code>Equatable</code> extension enabling error comparison for testing purposes</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/18/files#diff-77d80fff56131e13988e4c80373b8f9c370e585ce87ba0bdffd7b4da08baa215">+102/-28</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

