### PR TITLE
Extended RestOptions with dateDecodingStrategy so for each request th…

### DIFF
--- a/Sources/SwiftRestRequests/Deserializer.swift
+++ b/Sources/SwiftRestRequests/Deserializer.swift
@@ -29,6 +29,8 @@ public protocol Deserializer: Sendable {
     /// Value for the `Accept` header sent alongside the request (for example `application/json`).
     var acceptHeader: String { get }
 
+    var jsonDecoder: JSONDecoder? { get }
+    
     /// Creates a new instance of the deserializer.
     init()
 
@@ -44,12 +46,14 @@ public struct DecodableDeserializer<T: Decodable & Sendable>: Deserializer {
 
     public typealias ResponseType = T
 
+    public var jsonDecoder: JSONDecoder? = JSONDecoder()
+
     public let acceptHeader = MimeType.ApplicationJson.rawValue
 
     public init() { }
 
     public func deserialize(_ data: Data) throws -> T {
-        return try JSONDecoder().decode(T.self, from: data)
+        return try jsonDecoder!.decode(T.self, from: data)
     }
 }
 
@@ -59,6 +63,8 @@ public struct VoidDeserializer: Deserializer {
 
     public typealias ResponseType = Void
 
+    public var jsonDecoder: JSONDecoder? = nil
+    
     public let acceptHeader = MimeType.Void.rawValue
 
     public init() { }
@@ -74,6 +80,8 @@ public struct VoidDeserializer: Deserializer {
 public struct DataDeserializer: Deserializer {
 
     public typealias ResponseType = Data
+    
+    public var jsonDecoder: JSONDecoder? = nil
 
     public let acceptHeader = MimeType.ApplicationOctetStream.rawValue
 

--- a/Sources/SwiftRestRequests/RestApiCaller.swift
+++ b/Sources/SwiftRestRequests/RestApiCaller.swift
@@ -272,6 +272,9 @@ open class RestApiCaller : NSObject {
     /// - Returns: The data returned by server and the corresponding `HTTPURLResponse`
     private func makeCall<T: Deserializer>(_ relativePath: String?, httpMethod: HTTPMethod, payload: Data?, responseDeserializer: T, options: RestOptions) async throws -> (T.ResponseType?, HTTPStatusCode) {
         
+        // for deserializer with decoder set date decoding strategy
+        responseDeserializer.jsonDecoder?.dateDecodingStrategy = options.dateDecodingStrategy
+        
         let (data, httpResponse) = try await dataTask(relativePath: relativePath, httpMethod: httpMethod.rawValue, accept: responseDeserializer.acceptHeader, payload: payload, options: options)
        
         let httpStatus = httpResponse.status

--- a/Sources/SwiftRestRequests/RestOptions.swift
+++ b/Sources/SwiftRestRequests/RestOptions.swift
@@ -43,6 +43,9 @@ public struct RestOptions {
     /// Any response outside of this set triggers a `RestError.unexpectedHttpStatusCode`.
     public var expectedStatusCodes: [HTTPStatusCode]?
     
+    /// Decode the `Date` as an ISO-8601-formatted string (in RFC 3339 format).
+    public var dateDecodingStrategy = JSONDecoder.DateDecodingStrategy.iso8601
+    
     /// Creates a new instance with default timeout and without overrides.
     public init() {}
 }

--- a/Tests/SwiftRestRequestsTests/AbstractRestApiCallerTests.swift
+++ b/Tests/SwiftRestRequestsTests/AbstractRestApiCallerTests.swift
@@ -22,13 +22,6 @@ class AbstractRestApiCallerTests: XCTestCase {
         loggingLock.lock()
         defer { loggingLock.unlock() }
         
-        #if os(Linux)
-            // Configure `swift-log` default logger
-        #else
-            /// Configure `swift-log` logging system to use OSLog backend
-            LoggingSystem.bootstrap(OSLogHandler.init)
-        #endif
-        
         Logger.SwiftRestRequests.security.logLevel = .trace
         Logger.SwiftRestRequests.interceptor.logLevel = .trace
         Logger.SwiftRestRequests.apiCaller.logLevel = .trace


### PR DESCRIPTION
### **User description**
…is can be set by default using .iso8601


___

### **PR Type**
Enhancement


___

### **Description**
- Add configurable `JSONDecoder` to `Deserializer` protocol for date decoding strategy

- Extend `RestOptions` with `dateDecodingStrategy` property defaulting to ISO-8601

- Apply date decoding strategy from `RestOptions` to deserializer's JSON decoder

- Remove platform-specific logging bootstrap code from test setup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  RestOptions["RestOptions<br/>dateDecodingStrategy"] -- "applies strategy" --> Deserializer["Deserializer<br/>jsonDecoder"]
  Deserializer -- "decodes dates" --> JSONDecoder["JSONDecoder<br/>with strategy"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Deserializer.swift</strong><dd><code>Add configurable JSONDecoder to deserializers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/Deserializer.swift

<ul><li>Add optional <code>jsonDecoder</code> property to <code>Deserializer</code> protocol<br> <li> Implement <code>jsonDecoder</code> in <code>DecodableDeserializer</code> with default <br><code>JSONDecoder()</code> instance<br> <li> Set <code>jsonDecoder</code> to <code>nil</code> in <code>VoidDeserializer</code> and <code>DataDeserializer</code><br> <li> Update deserialization to use instance decoder instead of creating new <br>one</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/19/files#diff-889e9da04434add9f3fd6d5e077cbf58330f1b8ef1982305b538d535e6204b13">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestApiCaller.swift</strong><dd><code>Apply date decoding strategy to deserializer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/RestApiCaller.swift

<ul><li>Apply <code>dateDecodingStrategy</code> from <code>RestOptions</code> to deserializer's JSON <br>decoder before making request<br> <li> Add comment explaining date decoding strategy configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/19/files#diff-eca05e20a1c02fc0d2ffa8734b5d7287738d9920f8a164f95438472568515152">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestOptions.swift</strong><dd><code>Add configurable date decoding strategy option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/RestOptions.swift

<ul><li>Add <code>dateDecodingStrategy</code> property to <code>RestOptions</code> struct<br> <li> Default to <code>JSONDecoder.DateDecodingStrategy.iso8601</code> for consistent <br>date handling<br> <li> Include documentation comment explaining ISO-8601 RFC 3339 format</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/19/files#diff-c4801ccf3f1b9d5f645723bf406c70e6182b43c7ffd8baf286da1a07ab400c9d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractRestApiCallerTests.swift</strong><dd><code>Remove platform-specific logging bootstrap code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Tests/SwiftRestRequestsTests/AbstractRestApiCallerTests.swift

<ul><li>Remove platform-specific conditional compilation block for logging <br>bootstrap<br> <li> Simplify test setup by removing <code>#if os(Linux)</code> and <code>OSLogHandler</code> <br>initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/19/files#diff-42367121dc78136bd14bc46e8b1cdd3f514681de6ba8402c869ad63977e3989e">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

