### PR TITLE
Fixed compiler warnings coming from Sendable conformity

### DIFF
--- a/Sources/SwiftRestRequests/RestApiCaller.swift
+++ b/Sources/SwiftRestRequests/RestApiCaller.swift
@@ -40,7 +40,7 @@ public typealias HeaderGenerator = @Sendable (URL) -> [String : String]?
 /// Interceptors can mutate the `URLRequest` before it is sent or observe the `HTTPURLResponse` and payload
 /// after it is received. Register interceptors on `RestApiCaller` to build cross-cutting features such as
 /// logging, analytics, or header injection.
-@preconcurrency public protocol URLRequestInterceptor: AnyObject {
+public protocol URLRequestInterceptor: AnyObject, Sendable {
     /// Called immediately before the request is executed. Mutate `request` in place to apply changes.
     func invokeRequest(request: inout URLRequest, for session: URLSession);
     /// Called after the response has been received. The default implementation does nothing.

--- a/Sources/SwiftRestRequests/interceptors/LogNetworkInterceptor.swift
+++ b/Sources/SwiftRestRequests/interceptors/LogNetworkInterceptor.swift
@@ -29,7 +29,7 @@ import FoundationNetworking
 import Logging
 
 /// Interceptor that logs outgoing requests and incoming responses using `swift-log`.
-open class LogNetworkInterceptor: URLRequestInterceptor {
+open class LogNetworkInterceptor: URLRequestInterceptor, @unchecked Sendable {
     
     static let noBody =  "none"
     

--- a/Sources/SwiftRestRequests/security/AuthorizerInterceptor.swift
+++ b/Sources/SwiftRestRequests/security/AuthorizerInterceptor.swift
@@ -26,7 +26,7 @@ import FoundationNetworking
 
 
 /// Interceptor that injects authorization headers using a `URLRequestAuthorizer`.
-public class AuthorizerInterceptor: URLRequestInterceptor {
+public final class AuthorizerInterceptor: URLRequestInterceptor {
     
     /// Authorizer applied to each request.
     public let authorizer: any URLRequestAuthorizer

--- a/Sources/SwiftRestRequests/security/URLRequestAuthorizer.swift
+++ b/Sources/SwiftRestRequests/security/URLRequestAuthorizer.swift
@@ -30,13 +30,13 @@ import FoundationNetworking
 
 
 /// Protocol adopted by components that can apply authentication headers to requests.
-@preconcurrency public protocol URLRequestAuthorizer {
+public protocol URLRequestAuthorizer: Sendable {
     /// Updates the request with the appropriate authorization header.
     func configureAuthorizationHeader(for urlRequest: inout URLRequest);
 }
 
 /// Configures `Authorization` headers for HTTP Basic authentication.
-public class BasicRequestAuthorizer: URLRequestAuthorizer {
+public final class BasicRequestAuthorizer: URLRequestAuthorizer {
     
     let logger: Logger
     
@@ -71,12 +71,12 @@ public class BasicRequestAuthorizer: URLRequestAuthorizer {
 }
 
 /// Configures `Authorization` headers for Bearer token authentication.
-public class BearerRequestAuthorizer: URLRequestAuthorizer {
+public final class BearerRequestAuthorizer: URLRequestAuthorizer {
     
     let logger: Logger
     
     // The token value (without `Bearer` prefix) to be used for the HTTP `Authorization` request header.
-    public var token: String
+    public let token: String
     
     /// Creates a Bearer authorization helper with the provided token.
     /// - Parameters:
@@ -97,7 +97,7 @@ public class BearerRequestAuthorizer: URLRequestAuthorizer {
 
 
 /// No-op authorizer used when requests must remain unauthenticated.
-public class NoneAuthorizer: URLRequestAuthorizer {
+public final class NoneAuthorizer: URLRequestAuthorizer {
     
     public init() {}
     

--- a/Sources/SwiftRestRequests/security/URLRequestAuthorizer.swift
+++ b/Sources/SwiftRestRequests/security/URLRequestAuthorizer.swift
@@ -90,7 +90,7 @@ public final class BearerRequestAuthorizer: URLRequestAuthorizer {
     /// Applies the Bearer authorization header to the request.
     public func configureAuthorizationHeader(for urlRequest: inout URLRequest) {
         logger.trace("Set HTTP Authorization header", metadata: [
-            "Authorization": "Bearer \(self.token)"])
+            "Authorization": "Bearer *****"])
         urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
     }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replaced `@preconcurrency` attributes with explicit `Sendable` conformance

- Made protocol implementations `final` to ensure thread-safety

- Changed mutable property to immutable in `BearerRequestAuthorizer`

- Applied `@unchecked Sendable` to `LogNetworkInterceptor` for compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["@preconcurrency protocols"] -->|Replace with| B["Sendable conformance"]
  C["Open classes"] -->|Make final| D["Final classes"]
  E["Mutable var token"] -->|Change to| F["Immutable let token"]
  B --> G["Resolve compiler warnings"]
  D --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RestApiCaller.swift</strong><dd><code>Add Sendable conformance to URLRequestInterceptor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/RestApiCaller.swift

<ul><li>Replaced <code>@preconcurrency</code> attribute with explicit <code>Sendable</code> protocol <br>conformance<br> <li> Protocol now declares <code>URLRequestInterceptor: AnyObject, Sendable</code></ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/22/files#diff-eca05e20a1c02fc0d2ffa8734b5d7287738d9920f8a164f95438472568515152">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LogNetworkInterceptor.swift</strong><dd><code>Add unchecked Sendable conformance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/interceptors/LogNetworkInterceptor.swift

<ul><li>Added <code>@unchecked Sendable</code> conformance to class declaration<br> <li> Maintains compatibility with Sendable protocol requirements</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/22/files#diff-cab7ae641bfc2453271f6de21e10c2cc8998f726915476fd12c03b6f1d393dc3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AuthorizerInterceptor.swift</strong><dd><code>Make AuthorizerInterceptor final</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/security/AuthorizerInterceptor.swift

<ul><li>Changed class from <code>public</code> to <code>public final</code><br> <li> Ensures thread-safety and prevents unsafe subclassing</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/22/files#diff-6e84f18deaf7a7b21ef1753251c4ec827e0868823098a5036d873d15236356c2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>URLRequestAuthorizer.swift</strong><dd><code>Add Sendable conformance and finalize authorizer classes</code>&nbsp; </dd></summary>
<hr>

Sources/SwiftRestRequests/security/URLRequestAuthorizer.swift

<ul><li>Replaced <code>@preconcurrency</code> with explicit <code>Sendable</code> protocol conformance<br> <li> Made <code>BasicRequestAuthorizer</code> final class<br> <li> Made <code>BearerRequestAuthorizer</code> final class and changed <code>token</code> from <code>var</code> to <br><code>let</code><br> <li> Made <code>NoneAuthorizer</code> final class</ul>


</details>


  </td>
  <td><a href="https://github.com/tkausch/SwiftRestRequests/pull/22/files#diff-14c2b325f6b5e8b13057b02d3ab54cff529416549767cafff908d2964ad7f447">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

